### PR TITLE
add import buttons for Local Assistant Blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ If you have something to share here, feel free to PR it or ask to be added to th
 Blueprint to initiate media playback using pure local intent handling (custom sentences) so no Cloud-LLM involved.
 This however means that requests need to be very carefuly formulated.
 
-The Blueprint is located in the local-assistant-blueprint folder of this repository.
+The Blueprint is located in the `local-assist-blueprint` folder of this repository and can be imported by using the following buttons:
 
+* English: [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fvoice-support%2Fblob%2Fmain%2Flocal-assist-blueprint%2Fmass_assist_blueprint_en.yaml)
+* German: [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fvoice-support%2Fblob%2Fmain%2Flocal-assist-blueprint%2Fmass_assist_blueprint_de.yaml)
 ### Usage
 
 All sentences must:


### PR DESCRIPTION
fix `local-assist-blueprint` folder in readme & add install buttons for local assist blueprints