### PR TITLE
Set radio mode for all supported types

### DIFF
--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -268,7 +268,7 @@ sequence:
         artist: "{{ artist | default('NA', true) }}"
         album: "{{ album | default('NA', true) }}"
         radio_mode: >
-          {{ false if play_continuously == 'Never' else play_continuously == 'Always' and media_type in ['track', 'playlist'] or 'NA' }}
+          {{ false if play_continuously == 'Never' else play_continuously == 'Always' and media_type != 'radio' or 'NA' }}
   - alias: Play music using Music Assistant
     action: music_assistant.play_media
     data: "{{ dict(action_data.items() | rejectattr('1', 'eq', 'NA')) }}"


### PR DESCRIPTION
The blueprint only set `radio_mode` for `track` and `album`.
This PR changes that, and sets `radio_mode` for all media types except for `radio` (when the play continuously setting is set to `Always`)