### PR TITLE
Add Media Description as variable to the LLM script blueprint

### DIFF
--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -2,17 +2,18 @@ blueprint:
   name: LLM Script for Music Assitant voice requests
   source_url: https://github.com/music-assistant/voice-support/blob/main/llm-script-blueprint/llm_voice_script.yaml
   description:
-    "![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
+    '![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
 
     # Creates a script which will allow voice requests for Music Assistant
 
-    * None of the settings below are required to change for this script to work. But it
-    could be that for your specific LLM integration some finetuning is required. To do
-    that you can adjust the prompts sent to the LLM.
+    * None of the settings below are required to change for this script to work. But
+    it could be that for your specific LLM integration some finetuning is required.
+    To do that you can adjust the prompts sent to the LLM.
 
     * **Make sure to expose the script to Assist after creating it.**
 
-    * **Make sure to give the script a clear description.** An example can be found below.
+    * **Make sure to give the script a clear description.** An example can be found
+    below.
 
     * It is possible to add additional actions to be performed after the Music Assistant
     play media action. There are several variables available which are described below.
@@ -21,11 +22,11 @@ blueprint:
     ## Example for script description
 
     `This script is used to play music based on a voice request. The tool takes the
-    following arguments: media_type, artist, album, media_id, radio_mode, area. media_id and 
-    media_type are always required and must always be supplied as arguments to this tool.
-    An area or Music Assistant media player can optionally be provided in the voice request
-    as well. Use the parameters as described in the description of each parameter. Use this
-    tool whenever the user requests to play music.`
+    following arguments: media_type, artist, album, media_id, radio_mode, area. media_id,
+    media_type are always required and must always be supplied as arguments to this
+    tool. An area or Music Assistant media player can optionally be provided in the
+    voice request as well. Use the parameters as described in the description of each
+    parameter. Use this tool whenever the user requests to play music.`
 
     ## Available variables for additional actions
 
@@ -34,34 +35,38 @@ blueprint:
     |---|---|
 
     |`media_id`|The general description of the media, can be a song name, radio station,
-    album name, etc. In case there are multiple values (e.g. 5 song titles) they will be
-    seperated by a semicolon (`;`)|
+    album name, etc. In case there are multiple values (e.g. 5 song titles) they will
+    be seperated by a semicolon (`;`)|
 
-    |`media_type`|Will be one of the following: `'track'`, `'artist'`, `'album'`,
-    `'playlist'`, `'radio'`|
+    |`media_type`|Will be one of the following: `"track"`, `"artist"`, `"album"`,
+    `"playlist"`, `"radio"`|
 
-    |`artist`|The artist requested in the voice command. Will be empty in case the artist
-    is not relevant or when there are multiple artists requested|
+    |`artist`|The artist requested in the voice command. Will be empty in case the
+    artist is not relevant or when there are multiple artists requested|
 
-    |`album`|The album requested in the voice command, will be empty in case the album is
-    not relevant or when multiple albums are requested|
+    |`album`|The album requested in the voice command, will be empty in case the album
+    is not relevant or when multiple albums are requested|
 
-    |`area`|The area(s) determined by the LLM in which the request will be played. The
-    variable will undefined in case there was no area information, in case it is defined
-    it will be a list of area_id's|
+    |`media_description`|The description used in the voice request to describe
+    the media. For example if the voice request was "Play the best songs from Queen
+    in the living room" the value for this variable will be "the best songs from Queen"
 
-    |`media_player`|The Music Assitant media player(s) determined by the LLM on which the
-    request will be played. The variable will be undefined in case there was no media
-    player provided in the request, in case it it defined it should be a list entity_id's,
-    but it could be the LLM provided names instead.
+    |`area`|The area(s) determined by the LLM in which the request will be played.
+    The variable will undefined in case there was no area information, in case it
+    is defined it will be a list of area_ids|
 
-    |`default_player`|The default player provided when setting up the script, will be
-    `none` in case no player is provided|
+    |`media_player`|The Music Assitant media player(s) determined by the LLM on which
+    the request will be played. The variable will be undefined in case there was no
+    media player provided in the request, in case it it defined it should be a list
+    entity_ids, but it could be the LLM provided names instead.
+
+    |`default_player`|The default player provided when setting up the script, will
+    be `none` in case no player is provided|
 
     |`target_data`|The target data based on the input by the LLM, and `default_player`.
-    It will be a dictionary with the keys `area_id` and `entity_id`. The value will be
-    (a list of) id's relevant for the key or `'NA'` in case it was not used. Example:
-    `{'area_id': ['living_room'], 'entity_id', 'NA'}`|"
+    It will be a dictionary with the keys `area_id` and `entity_id`. The value will
+    be (a list of) ids relevant for the key or `"NA"` in case it was not used.
+    Example: `{"area_id": ["living_room"], "entity_id", "NA"}`|'
   domain: script
   author: TheFes
   homeassistant:
@@ -204,6 +209,20 @@ blueprint:
             - If the search is a radio channel: Then media_id is the requested channel.
 
             This is a mandatory argument and must always be provided.'
+        media_description_prompt:
+          name: Media Description Prompt
+          description: 
+            'The prompt which will be used to the LLM can provice the media description'
+          selector:
+            text:
+              multiline: true
+              multiple: false
+          default:
+            'The "media_description" key is used to describe the media which will
+            be played. This can be taken from the voice command query, but it should be
+            only the part which is relevant for the media. So if the voice request is
+            "Play the best Queen songs on the living room player" the value for
+            "media_description" should be "the best Queen songs"'
         area_prompt:
           name: Area Prompt
           description: The prompt which will be used to the LLM can provice the media_id
@@ -245,7 +264,7 @@ blueprint:
         actions:
           name: Additional actions
           selector:
-            action:
+            action: {}
           default: []
 mode: parallel
 max_exceeded: silent
@@ -283,6 +302,12 @@ fields:
     name: Media ID
     description: !input media_id_prompt
     required: true
+  media_description:
+    selector:
+      text:
+    name: Media Description
+    description: !input media_description_prompt
+    required: true
   area:
     selector:
       area:
@@ -304,17 +329,27 @@ fields:
 sequence:
   - variables:
       default_player: !input default_player
-      player_data: "{% set ma = integration_entities('music_assistant') %}
+      player_data: "{% set ma = integration_entities('music_assistant') %} 
+        
         {% set ma_names = ma | map('state_attr', 'friendly_name') | list %}
-        {% set ns = namespace(players=[]) %}
-        {% for player in media_player | default([], true) %}
-        {% if player in ma %}
-        {% set ns.players = ns.players + [player] %}
+        
+        {% set ns = namespace(players=[]) %} {% for player in media_player 
+        | default([], true) %}
+
+        {% if player in ma %} 
+        
+        {% set ns.players = ns.players + [player] %} 
+        
         {% elif player in ma_names %}
+        
         {% set entity = ma | select('is_state_attr', 'friendly_name', player) | list %}
+        
         {% set ns.players = ns.players + entity %}
-        {% endif %}
-        {% endfor %}
+        
+        {% endif %} 
+        
+        {% endfor %} 
+        
         {{ ns.players }}"
       target_data:
         area_id: "{{ area | default('NA', true) }}"


### PR DESCRIPTION
Adds `media_description` variable. This is the description of the media as used in the voice request.

This can be used in the optional actions afterwards, for ecample show on a LED matrix that the request will be performed. 