### PR TITLE
Change Radio Mode for LLM automation and script

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -79,28 +79,28 @@ blueprint:
               multiple: false
           default:
         play_continuously:
-          name: Play Continuously
-          description: 'Determines if the "radio_mode" setting should be set for the
-            play media action.
+          name: Radio Mode
+          description: >
+            Determines if the "radio_mode" setting should be set for the play media action.
 
+            When set to "Use player settings" it will use the "Don't stop the music" setting
+            on the Music Assistant Player
+            
             When set to "Always" it the player will continuously all new songs to
             the playlist.
 
             When set to "Never" the player will stop playing after the songs selected
             by the LLM are finished.
-
-            When set to "Use player settings" it will use the settings as set on the
-            Music Assistant Player'
           selector:
             select:
               options:
+              - Use player settings
               - Always
               - Never
-              - Use player settings
               multiple: false
               custom_value: false
               sort: false
-          default: Always
+          default: Use player settings
     response_settings:
       name: Response settings for Assist
       icon: mdi:chat

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -94,29 +94,28 @@ blueprint:
               multiple: false
           default:
         play_continuously:
-          name: Play Continuously
-          description:
-            'Determines if the "radio_mode" setting should be set for the
-            play media action.
+          name: Radio Mode
+          description: >
+            Determines if the "radio_mode" setting should be set for the play media action.
 
+            When set to "Use player settings" it will use the "Don't stop the music" setting
+            on the Music Assistant Player
+            
             When set to "Always" it the player will continuously all new songs to
             the playlist.
 
             When set to "Never" the player will stop playing after the songs selected
             by the LLM are finished.
-
-            When set to "Use player settings" it will use the settings as set on the
-            Music Assistant Player'
           selector:
             select:
               options:
-                - Always
-                - Never
-                - Use player settings
+              - Use player settings
+              - Always
+              - Never
               multiple: false
               custom_value: false
               sort: false
-          default: Always
+          default: Use player settings
     prompt_settings:
       name: Prompt settings for the LLM
       icon: mdi:robot


### PR DESCRIPTION
* Rename "Play Continously" to "Radio Mode"
* Make "Use player settings" the default
* Reorder the options so the default setting is the first one

The key for the setting in the blueprint is still `play_continuously` so this change is not breaking for users who already set up a script or automation using the blueprint

as discussed with @marcelveldt on Discord