### PR TITLE
Fix default player being targeted when area is provided in LLM script 

### DIFF
--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -238,7 +238,8 @@ blueprint:
             In case the area can not be determined from the request, or the device
             the request comes from, no not use this parameter
 
-            Use the "area" parameter or the "media_player" parameter. Do not use both.'
+            Only use both the "area" parameter and the "media_player" parameter together 
+            in case both are specifically used in the request.'
         media_player_prompt:
           name: Media Player Prompt
           description: The prompt which will be used to the LLM can provice the media_id
@@ -251,7 +252,8 @@ blueprint:
             multiple media players to play the music on. This has to be the entity_id
             of a media player provided by the Music Assistant integration.
 
-            Use the "area" parameter or the "media_player" parameter. Do not use both.'
+             Only use both the "area" parameter and the "media_player" parameter together 
+            in case both are specifically used in the request.'
     addition_conditions_actions:
       name: Additional actions
       icon: mdi:wrench

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -1,4 +1,4 @@
-blueprint:
+zeblueprint:
   name: LLM Script for Music Assitant voice requests
   source_url: https://github.com/music-assistant/voice-support/blob/main/llm-script-blueprint/llm_voice_script.yaml
   description:
@@ -356,12 +356,12 @@ sequence:
         {{ ns.players }}"
       target_data:
         area_id: "{{ area | default('NA', true) }}"
-        entity_id: "{{ 'NA' if area | default and not player_data | default else (player_data or default_player) | default('NA', true) }}"
+        entity_id: "{{ 'NA' if area | default and not player_data else (player_data or default_player) | default('NA', true) }}"
       invalid_target:
         response: Unable to find valid target
   - if:
       - condition: template
-        value_template: "{{ not (area | default or player_data | default or default_player) }}"
+        value_template: "{{ not (area | default or player_data or default_player) }}"
     then:
       - stop: No valid target for Music Assistant Voice script found
         response_variable: invalid_target

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -232,7 +232,8 @@ blueprint:
               multiple: false
           default:
             'The area or areas for which the music is requested. In case no
-            area is provided, use the area the request comes from.
+            the request does not mention a target (either an area or a player), 
+            use the area the request comes from.
 
             In case the area can not be determined from the request, or the device
             the request comes from, no not use this parameter

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -358,7 +358,7 @@ sequence:
         response: Unable to find valid target
   - if:
       - condition: template
-        value_template: "{{ not (area | default or player_data or default_player) }}"
+        value_template: "{{ not (area | default or player_data | default or default_player) }}"
     then:
       - stop: No valid target for Music Assistant Voice script found
         response_variable: invalid_target

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -231,12 +231,12 @@ zeblueprint:
               multiline: true
               multiple: false
           default:
-            'The area or areas for which the music is requested. In case no
-            the request does not mention a target (either an area or a player), 
-            use the area the request comes from.
+            'The area or areas for which the music is requested. In case the request 
+            does not mention a target (either an area or a player), use the area 
+            the request comes from.
 
             In case the area can not be determined from the request, or the device
-            the request comes from, no not use this parameter
+            the request comes from, do not use this parameter.
 
             Only use both the "area" parameter and the "media_player" parameter together 
             in case both are specifically used in the request.'

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -1,4 +1,4 @@
-zeblueprint:
+blueprint:
   name: LLM Script for Music Assitant voice requests
   source_url: https://github.com/music-assistant/voice-support/blob/main/llm-script-blueprint/llm_voice_script.yaml
   description:

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -353,7 +353,7 @@ sequence:
         {{ ns.players }}"
       target_data:
         area_id: "{{ area | default('NA', true) }}"
-        entity_id: "{{ (player_data or default_player) | default('NA', true) }}"
+        entity_id: "{{ 'NA' if area | default else (player_data or default_player) | default('NA', true) }}"
       invalid_target:
         response: Unable to find valid target
   - if:

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -353,7 +353,7 @@ sequence:
         {{ ns.players }}"
       target_data:
         area_id: "{{ area | default('NA', true) }}"
-        entity_id: "{{ 'NA' if area | default else (player_data or default_player) | default('NA', true) }}"
+        entity_id: "{{ 'NA' if area | default and not player_data | default else (player_data or default_player) | default('NA', true) }}"
       invalid_target:
         response: Unable to find valid target
   - if:


### PR DESCRIPTION
When an `area` was provided by the LLM (either because it was part of the Voice request, or the request came from a device in an area with an MA player) the default player would also be targeted.