### PR TITLE
Make sure target information is a list for LLM enhanced automation

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -419,7 +419,7 @@ actions:
       device_area: "{{ area_id(trigger.device_id) }}"
       default_player: !input default_player
       backup_target:
-        "{{ dict(area_id=device_area) if device_area else dict(entity_id=default_player)
+        "{{ dict(area_id=[device_area]) if device_area else dict(entity_id=[default_player])
         }}"
       target_data: "{{ llm_target_data if llm_target else backup_target }}"
       target: "{{ dict(target_data.items() | selectattr('1')) }}"
@@ -451,7 +451,8 @@ actions:
         {% else %}
         no_target
         {% endif %}
-      area_list: "{{ target.get('area_id', []) | map('area_name') | list }}"
+      only_device_area: "{{ target.get('area_id', []) == [device_area] }}"
+      area_list: "{{ [] if only_device_area else target.get('area_id', []) | map('area_name') | list }}"
       area_info:
         "{{ area_list[:-1] | join(', ') ~ ' ' ~ combine ~ ' ' ~ area_list[-1] if area_list
         | count > 2 else area_list | join(' ' ~ combine ~ ' ') }}"


### PR DESCRIPTION
When the device area or default player was targeted in the LLM enhanced information, the area_id or entity_id was a list instead of the string. 

The templates for the response needs a list, so this made it check for an area for each single character, making it return `none` for each character.

Also made it not mention the area in case the only targeted area is de device area from the Voice satellite.