### PR TITLE
Fix llm_voice_script radio mode description

### DIFF
--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -101,7 +101,7 @@ blueprint:
             When set to "Use player settings" it will use the "Don't stop the music" setting
             on the Music Assistant Player
             
-            When set to "Always" it the player will continuously all new songs to
+            When set to "Always" the player will continuously add new songs to
             the playlist.
 
             When set to "Never" the player will stop playing after the songs selected


### PR DESCRIPTION
Fix wording for Radio mode 'Always' description in llm-script-blueprint