### PR TITLE
Also use area an player names in request if those are not exposed in LLM enhanced automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ The Blueprint is located in the `local-assist-blueprint` folder of this reposito
 All sentences must:
 
 - start with the words `Play` or `Listen to` followed by the item type `artist/track/album/playlist/radio station` and then the name of the item
-
 - for album and track be optionally followed by `by (the) artist` and then the artist name
-
 - then be optionally followed by an area name or device name
-
 - then, for artist, track, album or playlist, be optionally followed by the phrase `using radio mode`
 
 #### Acceptable variations
@@ -44,27 +41,16 @@ There are acceptable variations to some words and inclusion of the word `the` is
 *see the translated blueprints for translated examples*
 
 ```
-
 Play the artist Pink Floyd in the kitchen
-
 Listen to album Jagged Little Pill in the study
-
 Listen to the album Greatest Hits by the artist James Taylor in the kitchen
-
 Play track New Years Day in the bedroom
-
 Play track New Years Day in the bedroom using radio mode
-
 Play the song A Hard Days Night by Billy Joel in the bedroom
-
 Listen to the playlist Classic Rock in the study
-
 Listen to the radio station BBC Radio 1 in the bedroom
-
 Play the album Classical Nights on the Bedroom Sonos Speaker
-
 Listen to the record Classical Nights on the Bedroom Sonos Speaker
-
 Play the band U2
 ```
 
@@ -74,7 +60,6 @@ The blueprint is located in the `llm-enhanced-local-assist-blueprint` folder of 
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fvoice-support%2Fblob%2Fmain%2Fllm-enhanced-local-assist-blueprint%2Fmass_llm_enhanced_assist_blueprint_en.yaml)
 
-When importing the blueprint you can optionally change the trigger sentences and responses. This allows you to add extra sentence triggers, but it also allows you to translate the sentence triggers and responses to your own language.
 
 ### Configuration
 
@@ -83,14 +68,60 @@ When importing the blueprint you can optionally change the trigger sentences and
 3. Create the automation using the blueprint. Choose the LLM agent from step 1. Optionally you can change settings for Music Assistant playback such as a default player, and whether to use Play Continously. You can also adjust the way voice responses are created as well as tweak the LLM Prompt as needed for your particular model. See the setting descriptions for more information.
 4. Save the automation.
 
+
+### Blueprint setup
+
+#### Required 
+
+* Select an LLM conversation agent to be used with the automation. The blueprint is 
+intended to be used with an LLM conversation agent without control of the house.
+
+#### Optional
+
+* Set a `Default Player` to be used when no target is mentioned in the request and
+the request doesn't come from an area with a Music Assistant player.
+* Change the setting for `Radio Mode`. By default this is set to use the `Don't stop 
+the music` setting on the Music Assistant player.
+* Change the trigger sentence or add more, you can also use this to translate 
+the sentence to your own language.
+* Change the responses or translate them to your own language.
+* Change the setting to expose area names and player names to the LLM, the default 
+setting is to send them. In case you change the settings in the blueprint and 
+do not expose the area names and player names to the LLM, the name must exactly 
+match the name of the area or player in Home Assistant. So when the area name is 
+_Bedroom Sophia_ it does not work if you you say _Sophia's Bedroom_ or when the 
+Speech to Text conversion uses _Sofia_ instead of _Sophia_. Unfortunately aliases 
+can't be used in the automation, as there is no template to get the aliases of areas 
+or entities. Capitalization of words does't matter, so _bedroom sophia_ will still 
+match if the area name in Home Assitant is _Bedroom Sophia_
+* Change the prompt which is used to have the LLM provide the correct data. 
+You don't need to translate this if you use a different language.
+
+
 ### Usage
+
 All sentences must:
 
-- start with the words Play or Listen to followed by a query about what you want to play
-- then be optionally followed by one or more area namea and/or one or more device names to play the music on
+* start with the words `Play` or `Listen to` followed by a query about what you
+want to play
+* then be optionally followed by one or more area namea and/or one or more device
+names to play the music on.
 
-### Examples
-*see the translated blueprints for translated examples*
+### How the target for the media is determined:
+
+1. In case one or more areas and/or one or more Music Assistant players are mentioned 
+in the request, these areas and/or players are used.
+In case you don't expose the names, and the area or player mentioned doesn't match exactly 
+with the area or player name in Home Assistatn, Assist will use the `No target response`.
+2. If no target was mentioned in the request, the automation will first check if the 
+request came from a device in an area. If in there is also a Music Assistant player 
+in that same area, the music will be played there.
+3.  If no target was mentioned in the request and the voice satellite area could also 
+not be used, then the `Default Player` set in the blueprint will be used. In case no 
+`Default Player` is set, the `No target response` will be returned.
+
+
+#### Examples
 
 ```
 Play the best songs from Pink Floyd in the kitchen

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All sentences must:
 
 * start with the words `Play` or `Listen to` followed by a query about what you
 want to play
-* then be optionally followed by one or more area namea and/or one or more device
+* then be optionally followed by one or more area names and/or one or more device
 names to play the music on.
 
 ### How the target for the media is determined:
@@ -112,9 +112,9 @@ names to play the music on.
 1. In case one or more areas and/or one or more Music Assistant players are mentioned 
 in the request, these areas and/or players are used.
 In case you don't expose the names, and the area or player mentioned doesn't match exactly 
-with the area or player name in Home Assistatn, Assist will use the `No target response`.
+with the area or player name in Home Assistant, Assist will use the `No target response`.
 2. If no target was mentioned in the request, the automation will first check if the 
-request came from a device in an area. If in there is also a Music Assistant player 
+request came from a device in an area. If there is also a Music Assistant player 
 in that same area, the music will be played there.
 3.  If no target was mentioned in the request and the voice satellite area could also 
 not be used, then the `Default Player` set in the blueprint will be used. In case no 

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -49,7 +49,7 @@ blueprint:
     * start with the words `Play` or `Listen to` followed by a query about what you
     want to play
 
-    * then be optionally followed by one or more area namea and/or one or more device
+    * then be optionally followed by one or more area names and/or one or more device
     names to play the music on.
 
     ### How the target for the media is determined:
@@ -57,10 +57,10 @@ blueprint:
     1. In case one or more areas and/or one or more Music Assistant players are mentioned 
     in the request, these areas and/or players are used.
     In case you don't expose the names, and the area or player mentioned doesn't match exactly 
-    with the area or player name in Home Assistatn, Assist will use the `No target response`.
+    with the area or player name in Home Assistant, Assist will use the `No target response`.
 
     2. If no target was mentioned in the request, the automation will first check if the 
-    request came from a device in an area. If in there is also a Music Assistant player 
+    request came from a device in an area. If there is also a Music Assistant player 
     in that same area, the music will be played there.
 
     3.  If no target was mentioned in the request and the voice satellite area could also 
@@ -255,7 +255,7 @@ blueprint:
           description:
             Disable to not expose the names of areas in which there is
             a Music Assistant player to the LLM. In case this is disabled any 
-            plaer name used in the request has to exactly match the player name in 
+            player name used in the request has to exactly match the player name in 
             Home Assistant
           selector:
             boolean: {}
@@ -393,13 +393,13 @@ blueprint:
             should be played.
 
             {% if expose_areas %}These are the area names which have a Music Assantant
-            player: {{ area_names }}. Only use these area names for the "target_data. In
+            player: {{ area_names }}. Only use these area names for the "target_data". In
             case another are description is used in the request, try to map it to one of
             these area names."
             {% endif %}
 
             In case the query requests the music to be played in one or more areas
-            {% if expose_areas %}in which a Music Assitant player is located{% endif %},
+            {% if expose_areas %}in which a Music Assistant player is located{% endif %},
             use {"areas": ["area name"]} for "target_data". Always use a list with area
             names, even when there is only one. {% if expose_areas %}Try to match the
             areas mentioned in the request to the provided area names. Only use area names

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -3,9 +3,44 @@ blueprint:
   name: Music Assistant - Local LLM Enhanced Voice Support Blueprint
   source_url: https://github.com/music-assistant/voice-support/blob/main/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
   description:
-    " ![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
+    "![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
 
     # Play media using voice commands with LLM assistance
+
+
+    ### Blueprint setup
+
+    #### Required 
+
+    * Select an LLM conversation agent to be used with the automation. The blueprint is 
+    intended to be used with an LLM conversation agent without control of the house.
+    
+    #### Optional
+
+    * Set a `Default Player` to be used when no target is mentioned in the request and
+    the request doesn't come from an area with a Music Assistant player.
+
+    * Change the setting for `Radio Mode`. By default this is set to use the `Don't stop 
+    the music` setting on the Music Assistant player.
+
+    * Change the trigger sentence or add more, you can also use this to translate 
+    the sentence to your own language.
+
+    * Change the responses or translate them to your own language.
+
+    * Change the setting to expose area names and player names to the LLM, the default 
+    setting is to send them. In case you change the settings in the blueprint and 
+    do not expose the area names and player names to the LLM, the name must exactly 
+    match the name of the area or player in Home Assistant. So when the area name is 
+    _Bedroom Sophia_ it does not work if you you say _Sophia's Bedroom_ or when the 
+    Speech to Text conversion uses _Sofia_ instead of _Sophia_. Unfortunately aliases 
+    can't be used in the automation, as there is no template to get the aliases of areas 
+    or entities. Capitalization of words does't matter, so _bedroom sophia_ will still 
+    match if the area name in Home Assitant is _Bedroom Sophia_
+
+    * Change the prompt which is used to have the LLM provide the correct data. 
+    You don't need to translate this if you use a different language.
+
 
     ### Usage
 
@@ -15,7 +50,22 @@ blueprint:
     want to play
 
     * then be optionally followed by one or more area namea and/or one or more device
-    names to play the music on
+    names to play the music on.
+
+    ### How the target for the media is determined:
+
+    1. In case one or more areas and/or one or more Music Assistant players are mentioned 
+    in the request, these areas and/or players are used.
+    In case you don't expose the names, and the area or player mentioned doesn't match exactly 
+    with the area or player name in Home Assistatn, Assist will use the `No target response`.
+
+    2. If no target was mentioned in the request, the automation will first check if the 
+    request came from a device in an area. If in there is also a Music Assistant player 
+    in that same area, the music will be played there.
+
+    3.  If no target was mentioned in the request and the voice satellite area could also 
+    not be used, then the `Default Player` set in the blueprint will be used. In case no 
+    `Default Player` is set, the `No target response` will be returned.
 
 
     #### Examples
@@ -46,7 +96,7 @@ blueprint:
 
     Play the album that has the nude baby swimming in the water on the cover
 
-    ``` "
+    ```"
   homeassistant:
     min_version: 2024.6.0
   input:
@@ -85,19 +135,17 @@ blueprint:
         play_continuously:
           name: Radio Mode
           description:
-            'Determines if the "radio_mode" setting should be set for the
+            Determines if the "radio_mode" setting should be set for the
             play media action.
 
-            When set to "Use player settings" it will use the "Don''t stop the music"
+            When set to "Use player settings" it will use the "Don't stop the music"
             setting on the Music Assistant Player
 
-            When set to "Always" the player will continuously add new songs to
-            the playlist.
+            When set to "Always" the player will continuously add new songs to the
+            playlist.
 
             When set to "Never" the player will stop playing after the songs selected
             by the LLM are finished.
-
-            '
           selector:
             select:
               options:
@@ -112,21 +160,21 @@ blueprint:
       name: Trigger and response settings for Assist
       icon: mdi:chat
       description:
-        You can use this setting to set the responses Assist will give.
+        "You can use this setting to set the responses Assist will give.
         <media_info> will be replaced with a description of the requested media. You
         can use <area_info> and <player_info> which will be replaced with the area
         names or player names.
 
         This section also allows you to use the script in a different language, by
-        translating these fields to your own language.
+        translating these fields to your own language."
       collapsed: true
       input:
         trigger:
           name: Conversation trigger sentences
           description:
             You can add more triggers or adjust them here. Put text between
-            square brackets [ ] to make it optional, With round brackets ( ) and a pipe
-            character | you can enter multiple values which are treated as 'or'.
+            square brackets [ ] to make it optional, With round brackets ( ) and a
+            pipe character | you can enter multiple values which are treated as 'or'.
             { query } is a wildcard value which will contain the requested media and
             optionally the area or Music Assistant player.
           selector:
@@ -138,15 +186,15 @@ blueprint:
         combine_text:
           name: Conversation trigger sentences
           description:
-            This text will be used in the response in case muliple areas or
-            players are targeted. So if you request media to be played in the living room
-            and in the kitchen, the response will mention 'living room <and> kitchen'.
-            <and> will be replaced with the value from this parameter.
+            This text will be used in the response in case muliple areas
+            or players are targeted. So if you request media to be played in the living
+            room and in the kitchen, the response will mention 'living room <and>
+            kitchen'. <and> will be replaced with the value from this parameter.
           selector:
             text:
               multiline: false
               multiple: false
-          default: "and"
+          default: and
         no_target_response:
           name: No target response
           description:
@@ -197,8 +245,8 @@ blueprint:
           name: Expose Music Assistant Players
           description:
             Disable to not expose the names of the Music Assistant players
-            to the LLM. In case this is set to false you won't be able to target a
-            Music Assistant player in a voice command
+            to the LLM. In case this is disabled any area name used in the request 
+            has to exactly match the area name in Home Assistant
           selector:
             boolean: {}
           default: true
@@ -206,8 +254,9 @@ blueprint:
           name: Expose areas with Music Assistant Players
           description:
             Disable to not expose the names of areas in which there is
-            a Music Assistant player to the LLM. In case this is set to false you
-            won't be able to target an area in a voice command
+            a Music Assistant player to the LLM. In case this is disabled any 
+            plaer name used in the request has to exactly match the player name in 
+            Home Assistant
           selector:
             boolean: {}
           default: true
@@ -344,34 +393,38 @@ blueprint:
             should be played.
 
             {% if expose_areas %}These are the area names which have a Music Assantant
-            player: {{ area_names }}. Only use these area names for the "target_data"
-            {% endif %} 
-            
-            {% if expose_players %} These are the Music Assistant players in the 
-            system: {{ player_names }}. Only use these names for the "target_data"
+            player: {{ area_names }}. Only use these area names for the "target_data. In
+            case another are description is used in the request, try to map it to one of
+            these area names."
             {% endif %}
 
-            {% if expose_areas %}In case the query requests the music to be played
-            in one more areas in which a Music Assitant player is located, use {"areas":
-            ["area name"]} for "target_data". Always use a list with area names, even
-            when there is only one. Try to match the areas mentioned in the request
-            to the provided area names. Only use area names from the list provided.
-            When no area is mentioned in the voice request or no area could be matched,
-            use {"areas":[]}}{% endif %}{% if expose_players %}Use {"areas":[]}} {%
-            endif %}
+            In case the query requests the music to be played in one or more areas
+            {% if expose_areas %}in which a Music Assitant player is located{% endif %},
+            use {"areas": ["area name"]} for "target_data". Always use a list with area
+            names, even when there is only one. {% if expose_areas %}Try to match the
+            areas mentioned in the request to the provided area names. Only use area names
+            from the list provided. {% else %}Do not include articles like "the" at the start
+            of the area name. So if the request is "Play music from Queen in the kitchen" use
+            "kitchen" as area name. Besides removing the first article, use exactly what
+            was provided in the request.{% endif %}When no area is mentioned in the voice
+            request{% if expose_areas %} or no area could be matched{% endif %}, use
+            {"areas":[]}
 
-            {% if expose_players %}In case the query requests the music to be played
-            on one or more music assistant players, use {"players": ["player name"]}
-            for "target_data". Always use a list with the player names, even when
-            there is only one. Try to match the players mentioned in the request
-            to the provided player names. Only use player names from the list provided.
-            When no player is mentioned in the voice request or no player could be matched,
-            use {"players":[]} {% endif %}{% if expose_areas %}Use {"players":[]}}{% endif
-            %}
+            {% if expose_players %}These are the Music Assistant players in the system:
+            {{ player_names }}. Only use these names for the "target_data". In case another
+            player name is mentioned in the request, try to map it to one of these player
+            names.{% endif %}
 
-
-            {% if not (expose_areas or expose_players) %}Use the following for "target_data":
-            {"areas": [], "players": []}{% endif %}
+            In case the query requests the music to be played on one or more media players,
+            use {"players": ["player name"]} for "target_data". Always use a list with player
+            names, even when there is only one. {% if expose_players %}Try to match the
+            players mentioned in the request to the provided player names. Only use player names
+            from the list provided. {% else %}Do not include articles like "the" at the start
+            of the player name. So if the request is "Play music from Queen on the bedroom
+            Sonos" use "bedroom Sonos" as area name. Besides removing the first article, use
+            exactly what was provided in the request.{% endif %}When no player is mentioned
+            in the voice  request{% if expose_players %} or no player could be matched
+            {% endif %}, use {"players":[]}
 
 
             Note that the input query can be in a different language. For the "media_type"
@@ -407,25 +460,31 @@ actions:
   - alias: Store relevant part of LLM result in variable and define target
     variables:
       llm_result: "{{ result.response.speech.plain.speech | from_json }}"
+  - alias: Store relevant part of LLM result in variable and define target
+    variables:
       llm_target_data:
-        entity_id:
-          "{{ integration_entities('music_assistant') | expand | selectattr('name',
-          'in', llm_result.target_data.get('players', [])) | map(attribute='entity_id')
-          | list }}"
-        area_id: "{{ llm_result.target_data.get('areas', []) | map('area_id') |
-          select('in', integration_entities('music_assistant') | map('area_id')
-          | list) | list }}"
-      llm_target: "{{ iif(llm_target_data.entity_id or llm_target_data.area_id) }}"
-      device_area: "{{ area_id(trigger.device_id) }}"
+        entity_id: "{{ integration_entities('music_assistant') | expand 
+          | selectattr('name', 'in', player_names.split(', ') 
+          | select('search', llm_result.target_data.players | join('|'), ignorecase=true) 
+          | list) | map(attribute='entity_id') | list if llm_result.target_data.players 
+          else [] }}"
+        area_id:
+          "{{ area_names.split(', ') | select('search', llm_result.target_data.areas 
+          | join('|'), ignorecase=true) | map('area_id') 
+          | list if llm_result.target_data.areas else [] }}"
+      llm_target: "{{ iif(llm_result.target_data.players or llm_result.target_data.areas) 
+        }}"
+      device_area: 
+        "{{ area_id(trigger.device_id) if area_name(trigger.device_id) in area_names.split(', ') }}"
       default_player: !input default_player
       backup_target:
-        "{{ dict(area_id=[device_area]) if device_area else dict(entity_id=[default_player])
-        }}"
-      target_data: "{{ llm_target_data if llm_target else backup_target }}"
+        "{{ (dict(area_id=[device_area]) if device_area) or (dict(entity_id=[default_player])
+        if default_player) }}"
+      target_data: "{{ (llm_target_data if llm_target else backup_target) | default({}, true) }}"
       target: "{{ dict(target_data.items() | selectattr('1')) }}"
   - alias: Only try to play music when target was determined
     if:
-      - alias: Check if LLM was able to determine target
+      - alias: Check if it was possible to determine a target
         condition: template
         value_template: "{{ iif(target) }}"
     then:
@@ -441,30 +500,27 @@ actions:
         only_area: !input area_response
         only_player: !input player_response
         area_player: !input area_and_player_response
-      response: >
-        {% if iif(target.get('area_id') and target.get('entity_id')) %}
-        area_player
-        {% elif iif(target.get('area_id')) %}
-        only_area
-        {% elif iif(target.get('entity_id')) %}
-        only_player
-        {% else %}
-        no_target
-        {% endif %}
+      response: "{% if iif(target.get('area_id') and target.get('entity_id')) %}
+        area_player {% elif iif(target.get('area_id')) %} only_area {% elif iif(target.get('entity_id'))
+        %} only_player {% else %} no_target {% endif %}"
       only_device_area: "{{ target.get('area_id', []) == [device_area] }}"
-      area_list: "{{ [] if only_device_area else target.get('area_id', []) | map('area_name') | list }}"
+      area_list:
+        "{{ [] if only_device_area else target.get('area_id', []) | map('area_name')
+        | list }}"
       area_info:
-        "{{ area_list[:-1] | join(', ') ~ ' ' ~ combine ~ ' ' ~ area_list[-1] if area_list
-        | count > 2 else area_list | join(' ' ~ combine ~ ' ') }}"
+        "{{ area_list[:-1] | join(', ') ~ ' ' ~ combine ~ ' ' ~ area_list[-1]
+        if area_list | count > 2 else area_list | join(' ' ~ combine ~ ' ') }}"
       player_list:
-        "{{ target.get('entity_id') | map('state_attr', 'friendly_name') |
-        list }}"
+        "{{ target.get('entity_id') | map('state_attr', 'friendly_name')
+        | list }}"
       player_info:
-        "{{ player_list[:-1] | join(', ') ~ ' ' ~ combine ~ ' ' ~ player_list[-1] if
-        player_list | count > 2 else player_list | join(' ' ~ combine ~ ' ') }}"
+        "{{ player_list[:-1] | join(', ') ~ ' ' ~ combine ~ ' ' ~ player_list[-1]
+        if player_list | count > 2 else player_list | join(' ' ~ combine ~ ' ')
+        }}"
       media_info: "{{ llm_result.media_description }}"
   - alias: Set response for Assist
     set_conversation_response:
       "{{ responses[response] | replace('<media_info>', media_info)
-      | replace('<area_info>', area_info) | replace('<player_info>', player_info) }}"
+      | replace('<area_info>', area_info) | replace('<player_info>', player_info)
+      }}"
 mode: parallel


### PR DESCRIPTION
Fixes #29

This change allow the automation to also match for area names and player names when these are not exposed to the LLM.

The LLM will return the area names and/or player names from the request. In the automation those are then matched against the area names and player names available for Music Assistant.
The names do have to exactly match the names in Home Assistant (only capitalization doesn't matter).

Unfortunately aliases are not available for templating, so we can only check for the names.

I also added some more information on how the target is determined (which has preference above the other), both in the README and in the description of the blueprint.