### PR TITLE
Make triggers and response of Assist Automation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,24 @@ The Blueprint is located in the `local-assist-blueprint` folder of this reposito
 
 All sentences must:
 
-- start with the words `Play` or `Listen to` followed by the item type `artist/track/album/playlist/radio station` and then the name of the item
-- for album and track be optionally followed by `by (the) artist` and then the artist name
-- then be optionally followed by an area name or device name
-- then, for artist, track, album or playlist, be optionally followed by the phrase `using radio mode`
+* start with the words `Play` or `Listen to` followed by the item type `artist`/`track`/`album`/`playlist`/`radio` and then the name of the item
+* for album and track be optionally followed by `by [the] artist` and then the artist name
+* then be optionally followed by an area name or device name
+* then, for artist, track, album or playlist, be optionally followed by the phrase `using radio mode`
 
-#### Acceptable variations
+#### Accepted variations
 
-There are acceptable variations to some words and inclusion of the word `the` is optional.
+usage of the article `the` is optional
+
+|Media type|Accepted variations|
+|---|---|
+|`artist`|`band`, `group`|
+|`track`|`song`|
+|`radio`|`radio station`, `radio`|
+|`playlist`||
+
 
 #### Examples
-*see the translated blueprints for translated examples*
 
 ```
 Play the artist Pink Floyd in the kitchen

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ The Blueprint is located in the `local-assist-blueprint` folder of this reposito
 |English|[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fvoice-support%2Fblob%2Fmain%2Flocal-assist-blueprint%2Fmass_assist_blueprint_en.yaml)|
 |German|[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fvoice-support%2Fblob%2Fmain%2Flocal-assist-blueprint%2Fmass_assist_blueprint_de.yaml)|
 
+
+In case your language is not listed above, you provide tranlsations yourself in the blueprint settings.
+
+
+### Blueprint setup
+
+#### Required 
+
+* Set a `Default Player` to be used when no target is mentioned in the request and
+the request doesn't come from an area with a Music Assistant player.
+
+#### Optional
+
+* Change the trigger sentence or add more, you can also use this to translate 
+the sentence to your own language.
+
+* Change the responses or translate them to your own language.
+
+
 ### Usage
 *see the translated blueprints for translated usage*
 

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -192,7 +192,7 @@ actions:
         ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
         integration_entities('music_assistant')) | list }}
       player_entity_id_by_assist_area: >
-        {{ area_entities('woonkamer')
+        {{ area_entities(area_id(trigger.device_id))
         | select('in', integration_entities('music_assistant')) | list }}
       mass_player_entity_id: |
         {{ player_entity_id_by_player_name or player_entity_id_by_area_name 

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -2,7 +2,7 @@ blueprint:
   domain: automation
   name: Music Assistant - Local(only) Voice Support Blueprint
   source_url: https://github.com/music-assistant/voice-support/blob/main/local-assist-blueprint/mass_assist_blueprint_en.yaml
-  description: '
+  description: "
     ![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
 
     # Play media using voice commands
@@ -11,17 +11,30 @@ blueprint:
 
     All sentences must:
 
-    * start with the words `Play` or `Listen to` followed by the item type `artist/track/album/playlist/radio station` and then the name of the item
+    * start with the words `Play` or `Listen to` followed by the item type `artist`/`track`/`album`/`playlist`/`radio` and then the name of the item
 
-    * for album and track be optionally followed by `by (the) artist` and then the artist name
+    * for album and track be optionally followed by `by [the] artist` and then the artist name
 
     * then be optionally followed by an area name or device name
 
     * then, for artist, track, album or playlist, be optionally followed by the phrase `using radio mode`
 
-    #### Acceptable variations
+    #### Accepted variations
 
-    There are acceptable variations to some words and inclusion of the word `the` is optional.
+    usage of the article `the` is optional
+
+    |Media type|Accepted variations|
+
+    |---|---|
+
+    |`artist`|`band`, `group`|
+
+    |`track`|`song`|
+
+    |`radio`|`radio station`, `radio`|
+
+    |`playlist`||
+
 
     #### Examples
 
@@ -49,7 +62,7 @@ blueprint:
 
     Play the band U2
 
-    ```'
+    ```"
   input:
     default_player_entity_id_input:
       name: Default Media Player
@@ -62,21 +75,20 @@ blueprint:
       name: Trigger and response settings for Assist
       icon: mdi:chat
       description:
-        "You can change the existing triggers or add more triggers in these settings. 
-        Put text between square brackets [ ] to make it optional. With round brackets 
-        ( ) and a pipe character | you can enter multiple values which are treated as 
+        "You can change the existing triggers or add more triggers in these settings.
+        Put text between square brackets [ ] to make it optional. With round brackets
+        ( ) and a pipe character | you can enter multiple values which are treated as
         'or'. { query } is a wildcard value which will contain the requested media and
         optionally the area or Music Assistant player.
-        
+
         You can als set the responses Assist will give. It uses jinja templates which
-        will be replaced with the media information and player name of the Music Assistant 
+        will be replaced with the media information and player name of the Music Assistant
         player."
       collapsed: true
       input:
         album_trigger:
           name: Album trigger
-          description:
-            The trigger sentences to request a specific album.
+          description: The trigger sentences to request a specific album.
           selector:
             text:
               multiline: false
@@ -85,8 +97,7 @@ blueprint:
             - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
         track_trigger:
           name: Track trigger
-          description:
-            The trigger sentences to request a specific track.
+          description: The trigger sentences to request a specific track.
           selector:
             text:
               multiline: false
@@ -95,8 +106,7 @@ blueprint:
             - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
         artist_trigger:
           name: Artist trigger
-          description:
-            The trigger sentences to request music from a specific artist.
+          description: The trigger sentences to request music from a specific artist.
           selector:
             text:
               multiline: false
@@ -105,8 +115,7 @@ blueprint:
             - "(play|listen to) [the ](artist|band|group) {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
         radio_trigger:
           name: Radio trigger
-          description:
-            The trigger sentences to request a specific radio station.
+          description: The trigger sentences to request a specific radio station.
           selector:
             text:
               multiline: false
@@ -115,8 +124,7 @@ blueprint:
             - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name} [(in|on|using) [the ]{area_or_player_name}]"
         playlist_trigger:
           name: Playlist trigger
-          description:
-            The trigger sentences to request a specific playlist.
+          description: The trigger sentences to request a specific playlist.
           selector:
             text:
               multiline: false
@@ -125,8 +133,7 @@ blueprint:
             - "(play|listen to) [the ]playlist {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
         response_input:
           name: Response for Assist
-          description:
-            The response which will be given by Assist.
+          description: The response which will be given by Assist.
           selector:
             text:
               multiline: false
@@ -166,9 +173,9 @@ actions:
           | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)
           | map(attribute='entity_id') | list }}
       player_entity_id_by_area_name: >
-          {{ areas() | map('area_name') | select('match', area_or_player_name ~ '$', 
-          ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
-          integration_entities('music_assistant')) | list }}
+        {{ areas() | map('area_name') | select('match', area_or_player_name ~ '$', 
+        ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
+        integration_entities('music_assistant')) | list }}
       player_entity_id_by_assist_area: >
         {{ area_entities('woonkamer')
         | select('in', integration_entities('music_assistant')) | list }}

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -7,6 +7,21 @@ blueprint:
 
     # Play media using voice commands
 
+    ### Blueprint setup
+
+    #### Required 
+
+    * Set a `Default Player` to be used when no target is mentioned in the request and
+    the request doesn't come from an area with a Music Assistant player.
+    
+    #### Optional
+
+    * Change the trigger sentence or add more, you can also use this to translate 
+    the sentence to your own language.
+
+    * Change the responses or translate them to your own language.
+
+
     ### Usage
 
     All sentences must:

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -191,7 +191,7 @@ actions:
       mass_player_name: "{{ state_attr(mass_player_entity_id, 'friendly_name') }}"
   - alias: Send media to selected Music Assistant Player
     action: music_assistant.play_media
-    data: "{{ dict(action_data.items() | selectattr('2')) }}"
+    data: "{{ dict(action_data.items() | selectattr('1')) }}"
     target:
       entity_id: "{{ mass_player_entity_id }}"
   - alias: Send back the response

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -49,8 +49,7 @@ blueprint:
 
     Play the band U2
 
-    ```
-  '
+    ```'
   input:
     default_player_entity_id_input:
       name: Default Media Player
@@ -59,46 +58,115 @@ blueprint:
           filter:
             integration: music_assistant
             domain: media_player
-
+    trigger_response_settings:
+      name: Trigger and response settings for Assist
+      icon: mdi:chat
+      description:
+        "You can change the existing triggers or add more triggers in these settings. 
+        Put text between square brackets [ ] to make it optional. With round brackets 
+        ( ) and a pipe character | you can enter multiple values which are treated as 
+        'or'. { query } is a wildcard value which will contain the requested media and
+        optionally the area or Music Assistant player.
+        
+        You can als set the responses Assist will give. It uses jinja templates which
+        will be replaced with the media information and player name of the Music Assistant 
+        player."
+      collapsed: true
+      input:
+        album_trigger:
+          name: Album trigger
+          description:
+            The trigger sentences to request a specific album.
+          selector:
+            text:
+              multiline: false
+              multiple: true
+          default:
+            - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+        track_trigger:
+          name: Track trigger
+          description:
+            The trigger sentences to request a specific track.
+          selector:
+            text:
+              multiline: false
+              multiple: true
+          default:
+            - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+        artist_trigger:
+          name: Artist trigger
+          description:
+            The trigger sentences to request music from a specific artist.
+          selector:
+            text:
+              multiline: false
+              multiple: true
+          default:
+            - "(play|listen to) [the ](artist|band|group) {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+        radio_trigger:
+          name: Radio trigger
+          description:
+            The trigger sentences to request a specific radio station.
+          selector:
+            text:
+              multiline: false
+              multiple: true
+          default:
+            - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name} [(in|on|using) [the ]{area_or_player_name}]"
+        playlist_trigger:
+          name: Playlist trigger
+          description:
+            The trigger sentences to request a specific playlist.
+          selector:
+            text:
+              multiline: false
+              multiple: true
+          default:
+            - "(play|listen to) [the ]playlist {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+        response_input:
+          name: Response for Assist
+          description:
+            The response which will be given by Assist.
+          selector:
+            text:
+              multiline: false
+              multiple: false
+          default: "{{ trigger.slots.media_name }} playing on {{ mass_player_name }}"
 
 triggers:
   - trigger: conversation
-    command:
-      - "(play|listen to) [the ](album|ep|record|compilation|single) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+    command: !input album_trigger
     id: album
   - trigger: conversation
-    command:
-      - "(play|listen to) [the ](track|song) {media_name} [by [the ](artist|band|group) {artist}] [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+    command: !input track_trigger
     id: track
   - trigger: conversation
-    command:
-      - "(play|listen to) [the ](artist|band|group) {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+    command: !input artist_trigger
     id: artist
   - trigger: conversation
-    command:
-      - "(play|listen to) [the ]((radio station)|(radio)|(station)) {media_name} [(in|on|using) [the ]{area_or_player_name}]"
+    command: !input radio_trigger
     id: radio
   - trigger: conversation
-    command:
-      - "(play|listen to) [the ]playlist {media_name} [(in|on|using) [the ]{area_or_player_name}][ (with|using) {radio_mode}]"
+    command: !input playlist_trigger
     id: playlist
 conditions: []
 actions:
-  - variables:
+  - alias: Define variables to be used in the automation
+    variables:
       default_player_entity_id: !input default_player_entity_id_input
       trigger_id: "{{ trigger.id }}"
-      media_name: "{{ trigger.slots.media_name }}"
-      media_type: |
-        {% if 'radio' in media_name or 'Radio' in media_name %}
-          radio
-        {% else %}
-          {{ trigger_id }}
-        {% endif %}
-      artist: "{{ trigger.slots.artist }}"
-      area_or_player_name: "{{ trigger.slots.area_or_player_name }}"
+      area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
       assist_device_id: "{{ trigger.device_id }}"
-      radio_mode_str: "{{ trigger.slots.radio_mode or '' }}"
-      radio_mode: "{{ 'radio' in radio_mode_str.lower() }}"
+      action_data:
+        media_name: "{{ trigger.slots.media_name }}"
+        media_type: |
+          {% if 'radio' in media_name or 'Radio' in media_name %}
+            radio
+          {% else %}
+            {{ trigger_id }}
+          {% endif %}
+        artist: "{{ trigger.slots.artist | default }}"
+        radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default() | lower }}"
       player_entity_id_by_player_name: >
         {{ expand(integration_entities('music_assistant')) |
         selectattr("attributes.mass_player_type", 'defined') |
@@ -111,82 +179,21 @@ actions:
         join(', ', attribute="entity_id") }}
       player_entity_id_by_assist_area: |
         {% if assist_device_id and area_id(assist_device_id)  %}
-          {{ expand(area_entities(area_id(assist_device_id))) | selectattr("attributes.mass_player_type", 'defined')  | join(', ', attribute="entity_id") }}
+          {{ expand(area_entities(area_id(assist_device_id)))
+            | selectattr("attributes.mass_player_type", 'defined')
+            | join(', ', attribute="entity_id") }}
         {% else %}
           None
         {% endif %}
       mass_player_entity_id: |
-        {% if player_entity_id_by_player_name %}
-          {{ player_entity_id_by_player_name }}
-        {% elif player_entity_id_by_area_name %}
-          {{ player_entity_id_by_area_name }}
-        {% elif player_entity_id_by_assist_area  %}
-          {{ player_entity_id_by_assist_area }}
-        {% else %}
-          {{ default_player_entity_id }}
-        {% endif %}
+        {{ player_entity_id_by_player_name or player_entity_id_by_area_name 
+        or player_entity_id_by_assist_area or default_player_entity_id }}
       mass_player_name: "{{ state_attr(mass_player_entity_id, 'friendly_name') }}"
-  - choose:
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'album' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'track' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'artist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'radio' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'playlist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-  - set_conversation_response: "{{ trigger.slots.media_name }} playing on {{ mass_player_name }}"
+  - alias: Send media to selected Music Assistant Player
+    action: music_assistant.play_media
+    data: "{{ dict(action_data.items() | selectattr('2')) }}"
+    target:
+      entity_id: "{{ mass_player_entity_id }}"
+  - alias: Send back the response
+    set_conversation_response: !input response_input
 mode: single

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -158,7 +158,7 @@ actions:
       area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
       assist_device_id: "{{ trigger.device_id }}"
       action_data:
-        media_name: "{{ trigger.slots.media_name }}"
+        media_id: "{{ trigger.slots.media_name }}"
         media_type: |
           {% if 'radio' in media_name or 'Radio' in media_name %}
             radio

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -149,7 +149,6 @@ triggers:
   - trigger: conversation
     command: !input playlist_trigger
     id: playlist
-conditions: []
 actions:
   - alias: Define variables to be used in the automation
     variables:
@@ -159,36 +158,24 @@ actions:
       assist_device_id: "{{ trigger.device_id }}"
       action_data:
         media_id: "{{ trigger.slots.media_name }}"
-        media_type: |
-          {% if 'radio' in media_name or 'Radio' in media_name %}
-            radio
-          {% else %}
-            {{ trigger_id }}
-          {% endif %}
+        media_type: "{{ 'radio' if 'radio' in media_name | lower else trigger_id }}"
         artist: "{{ trigger.slots.artist | default }}"
-        radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default() | lower }}"
+        radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default | lower }}"
       player_entity_id_by_player_name: >
-        {{ expand(integration_entities('music_assistant')) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
+        {{ integration_entities('music_assistant') | expand 
+          | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)
+          | map(attribute='entity_id') | list }}
       player_entity_id_by_area_name: >
-        {{ expand(area_entities(area_or_player_name)) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
-      player_entity_id_by_assist_area: |
-        {% if assist_device_id and area_id(assist_device_id)  %}
-          {{ expand(area_entities(area_id(assist_device_id)))
-            | selectattr("attributes.mass_player_type", 'defined')
-            | join(', ', attribute="entity_id") }}
-        {% else %}
-          None
-        {% endif %}
+          {{ areas() | map('area_name') | select('match', area_or_player_name ~ '$', 
+          ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
+          integration_entities('music_assistant')) | list }}
+      player_entity_id_by_assist_area: >
+        {{ area_entities('woonkamer')
+        | select('in', integration_entities('music_assistant')) | list }}
       mass_player_entity_id: |
         {{ player_entity_id_by_player_name or player_entity_id_by_area_name 
-        or player_entity_id_by_assist_area or default_player_entity_id }}
-      mass_player_name: "{{ state_attr(mass_player_entity_id, 'friendly_name') }}"
+        or player_entity_id_by_assist_area or [default_player_entity_id] }}
+      mass_player_name: "{{ mass_player_entity_id | map('state_attr', 'friendly_name') | join(', ') }}"
   - alias: Send media to selected Music Assistant Player
     action: music_assistant.play_media
     data: "{{ dict(action_data.items() | selectattr('1')) }}"


### PR DESCRIPTION
To do:
* ~~properly test~~
* ~~adjust documentation~~
* ~~proofread ;)~~ (hopefully)

What's changed:
* triggers and response moved to blueprint inputs so they can be changed and/or translated
* documentation updated
* table added with accepted variations
* basically changed all templates, former ones could potentially have issues. It was expected that there would always be one player, but an area can potentially have multiple MA players in it. 