### PR TITLE
Remove keys for action_data in case value is none

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -490,7 +490,7 @@ actions:
     then:
       - alias: Play Music based on LLM result
         action: music_assistant.play_media
-        data: "{{ llm_result.action_data }}"
+        data: "{{ dict(llm_result.action_data.items() | rejectattr('1', 'none')) }}"
         target: "{{ target }}"
   - alias: Set variables for responses
     variables:


### PR DESCRIPTION
Sometimes an LLM provides `"artist", null` or `"album": null` instead of just not providing it. 

This change filters these keys out, so the play media action won't fail.