### PR TITLE
Prevent errors when LLM doesn't provide target info

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -456,13 +456,14 @@ actions:
       llm_target_data:
         entity_id:
           "{{ integration_entities('music_assistant') | expand | selectattr('name',
-          'in', player_names.split(', ') | select('search', llm_result.target_data.players
-          | join('|'), ignorecase=true) | list) | map(attribute='entity_id') | list
+          'in', player_names.split(', ') | select('search', 
+          llm_result.get('target_data', {}).get('players', []) | join('|'), 
+          ignorecase=true) | list) | map(attribute='entity_id') | list
           if llm_result.target_data.players else [] }}"
         area_id:
           "{{ area_names.split(', ') | select('search', llm_result.target_data.areas
-          | join('|'), ignorecase=true) | map('area_id') | list if llm_result.target_data.areas
-          else [] }}"
+          | join('|'), ignorecase=true) | map('area_id') | list if 
+          llm_result.get('target_data', {}).get('areas', []) else [] }}"
       llm_target:
         "{{ iif(llm_result.target_data.players or llm_result.target_data.areas)
         }}"

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -456,14 +456,13 @@ actions:
       llm_target_data:
         entity_id:
           "{{ integration_entities('music_assistant') | expand | selectattr('name',
-          'in', player_names.split(', ') | select('search', 
-          llm_result.get('target_data', {}).get('players', []) | join('|'), 
-          ignorecase=true) | list) | map(attribute='entity_id') | list
-          if llm_result.target_data.players else [] }}"
+          'in', player_names.split(', ') | select('search', llm_result.target_data.players
+          | join('|'), ignorecase=true) | list) | map(attribute='entity_id') | list
+          if llm_result.get('target_data', {}).get('players') else [] }}"
         area_id:
           "{{ area_names.split(', ') | select('search', llm_result.target_data.areas
           | join('|'), ignorecase=true) | map('area_id') | list if 
-          llm_result.get('target_data', {}).get('areas', []) else [] }}"
+          llm_result.get('target_data', {}).get('areas') else [] }}"
       llm_target:
         "{{ iif(llm_result.target_data.players or llm_result.target_data.areas)
         }}"


### PR DESCRIPTION
Some (smaller) LLM models might not return the `target_data`. 
This PR prevents errors in such cases by providing defaults.