### PR TITLE
Fix wrong input for areas or players

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -455,14 +455,16 @@ actions:
           == 'Always' and llm_result.action_data.media_type != 'radio' or 'NA' }}"
       llm_target_data:
         entity_id:
-          "{{ integration_entities('music_assistant') | expand | selectattr('name',
-          'in', player_names.split(', ') | select('search', llm_result.target_data.players
-          | join('|'), ignorecase=true) | list) | map(attribute='entity_id') | list
-          if llm_result.get('target_data', {}).get('players') else [] }}"
+          "{% set players = llm_result.get('target_data', {}).get('players', []) %}
+          {% set players = players | join('|') if players is list else players %}
+          {{ integration_entities('music_assistant') | expand | selectattr('name',
+          'in', player_names.split(', ') | select('search', players, ignorecase=true) 
+          | list) | map(attribute='entity_id') | list if players else [] }}"
         area_id:
-          "{{ area_names.split(', ') | select('search', llm_result.target_data.areas
-          | join('|'), ignorecase=true) | map('area_id') | list if 
-          llm_result.get('target_data', {}).get('areas') else [] }}"
+          "{% set areas = llm_result.get('target_data', {}).get('areas', []) %}
+          {% set areas = areas | join('|') if areas is list else areas %}
+          {{ area_names.split(', ') | select('search', areas, ignorecase=true) 
+          | map('area_id') | list if areas else [] }}"
       llm_target:
         "{{ iif(llm_result.get('target_data', {}).get('players') or 
         llm_result.get('target_data', {}).get('areas')) }}"


### PR DESCRIPTION
In case the LLM provides a list with an empty string, or a string value instead of a list, the `llm_target_data` will still be defined correctly.