### PR TITLE
Version management

### DIFF
--- a/llm-enhanced-local-assist-blueprint/changelog.md
+++ b/llm-enhanced-local-assist-blueprint/changelog.md
@@ -1,0 +1,7 @@
+![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
+
+# Changelog: Option 2 - LLM Enhanced automation
+
+## 20250128
+
+* Initial version when the changelog was created

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -427,6 +427,7 @@ triggers:
 actions:
   - alias: Store input from blueprint in variables so they can be used in the prompt
     variables:
+      version: 20250128
       expose_areas: !input expose_areas
       expose_players: !input expose_players
       play_continuously: !input play_continuously

--- a/llm-script-blueprint/changelog.md
+++ b/llm-script-blueprint/changelog.md
@@ -1,0 +1,7 @@
+![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
+
+# Changelog: Option 3 - Full LLM Script
+
+## 20250128
+
+* Initial version when the changelog was created

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -330,6 +330,7 @@ fields:
     description: !input media_player_prompt
 sequence:
   - variables:
+      version: 20250128
       default_player: !input default_player
       player_data: "{% set ma = integration_entities('music_assistant') %} 
         

--- a/local-assist-blueprint/changelog.md
+++ b/local-assist-blueprint/changelog.md
@@ -1,0 +1,7 @@
+![Image](https://github.com/music-assistant/voice-support/blob/main/assets/music-assistant.png?raw=true)
+
+# Changelog: Option 1 - Fully local automation
+
+## 20250128
+
+* Initial version when the changelog was created

--- a/local-assist-blueprint/mass_assist_blueprint_de.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_de.yaml
@@ -84,108 +84,35 @@ triggers:
 conditions: []
 actions:
   - variables:
+      version: 20250128
       default_player_entity_id: !input default_player_entity_id_input
       trigger_id: "{{ trigger.id }}"
-      media_name: "{{ trigger.slots.media_name }}"
-      media_type: |
-        {% if 'radio' in media_name or 'Radio' in media_name %}
-          radio
-        {% else %}
-          {{ trigger_id }}
-        {% endif %}
-      artist: "{{ trigger.slots.artist }}"
-      area_or_player_name: "{{ trigger.slots.area_or_player_name }}"
+      area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
       assist_device_id: "{{ trigger.device_id }}"
-      radio_mode_str: "{{ trigger.slots.radio_mode or '' }}"
-      radio_mode: "{{ 'radio' in radio_mode_str.lower() }}"
+      action_data:
+        media_id: "{{ trigger.slots.media_name }}"
+        media_type: "{{ 'radio' if 'radio' in media_name | lower else trigger_id }}"
+        artist: "{{ trigger.slots.artist | default }}"
+        radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default | lower }}"
       player_entity_id_by_player_name: >
-        {{ expand(integration_entities('music_assistant')) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
+        {{ integration_entities('music_assistant') | expand 
+          | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)
+          | map(attribute='entity_id') | list }}
       player_entity_id_by_area_name: >
-        {{ expand(area_entities(area_or_player_name)) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
-      player_entity_id_by_assist_area: |
-        {% if assist_device_id and area_id(assist_device_id)  %}
-          {{ expand(area_entities(area_id(assist_device_id))) | selectattr("attributes.mass_player_type", 'defined')  | join(', ', attribute="entity_id") }}
-        {% else %}
-          None
-        {% endif %}
+        {{ areas() | map('area_name') | select('match', area_or_player_name ~ '$', 
+        ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
+        integration_entities('music_assistant')) | list }}
+      player_entity_id_by_assist_area: >
+        {{ area_entities(area_id(trigger.device_id))
+        | select('in', integration_entities('music_assistant')) | list }}
       mass_player_entity_id: |
-        {% if player_entity_id_by_player_name %}
-          {{ player_entity_id_by_player_name }}
-        {% elif player_entity_id_by_area_name %}
-          {{ player_entity_id_by_area_name }}
-        {% elif player_entity_id_by_assist_area  %}
-          {{ player_entity_id_by_assist_area }}
-        {% else %}
-          {{ default_player_entity_id }}
-        {% endif %}
-      mass_player_name: "{{ state_attr(mass_player_entity_id, 'friendly_name') }}"
-  - choose:
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'album' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'track' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'artist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'radio' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'playlist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
+        {{ player_entity_id_by_player_name or player_entity_id_by_area_name 
+        or player_entity_id_by_assist_area or [default_player_entity_id] }}
+      mass_player_name: "{{ mass_player_entity_id | map('state_attr', 'friendly_name') | join(', ') }}"
+  - alias: Send media to selected Music Assistant Player
+    action: music_assistant.play_media
+    data: "{{ dict(action_data.items() | selectattr('1')) }}"
+    target:
+      entity_id: "{{ mass_player_entity_id }}"
   - set_conversation_response: "{{ trigger.slots.media_name }} wird auf {{ mass_player_name }} abgespielt"
 mode: single

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -174,6 +174,7 @@ triggers:
 actions:
   - alias: Define variables to be used in the automation
     variables:
+      version: 20250128
       default_player_entity_id: !input default_player_entity_id_input
       trigger_id: "{{ trigger.id }}"
       area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"

--- a/local-assist-blueprint/mass_assist_blueprint_nl.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_nl.yaml
@@ -85,108 +85,35 @@ triggers:
 conditions: []
 actions:
   - variables:
+      version: 20250128
       default_player_entity_id: !input default_player_entity_id_input
       trigger_id: "{{ trigger.id }}"
-      media_name: "{{ trigger.slots.media_name }}"
-      media_type: |
-        {% if 'radio' in media_name or 'Radio' in media_name %}
-          radio
-        {% else %}
-          {{ trigger_id }}
-        {% endif %}
-      artist: "{{ trigger.slots.artist }}"
-      area_or_player_name: "{{ trigger.slots.area_or_player_name }}"
+      area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
       assist_device_id: "{{ trigger.device_id }}"
-      radio_mode_str: "{{ trigger.slots.radio_mode or '' }}"
-      radio_mode: "{{ 'radio' in radio_mode_str.lower() }}"
+      action_data:
+        media_id: "{{ trigger.slots.media_name }}"
+        media_type: "{{ 'radio' if 'radio' in media_name | lower else trigger_id }}"
+        artist: "{{ trigger.slots.artist | default }}"
+        radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default | lower }}"
       player_entity_id_by_player_name: >
-        {{ expand(integration_entities('music_assistant')) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
+        {{ integration_entities('music_assistant') | expand 
+          | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)
+          | map(attribute='entity_id') | list }}
       player_entity_id_by_area_name: >
-        {{ expand(area_entities(area_or_player_name)) |
-        selectattr("attributes.mass_player_type", 'defined') |
-        selectattr("attributes.friendly_name", 'equalto', area_or_player_name) |
-        join(', ', attribute="entity_id") }}
-      player_entity_id_by_assist_area: |
-        {% if assist_device_id and area_id(assist_device_id)  %}
-          {{ expand(area_entities(area_id(assist_device_id))) | selectattr("attributes.mass_player_type", 'defined')  | join(', ', attribute="entity_id") }}
-        {% else %}
-          None
-        {% endif %}
+        {{ areas() | map('area_name') | select('match', area_or_player_name ~ '$', 
+        ignorecase=true) | map('area_entities') | sum(start=[]) | select('in', 
+        integration_entities('music_assistant')) | list }}
+      player_entity_id_by_assist_area: >
+        {{ area_entities(area_id(trigger.device_id))
+        | select('in', integration_entities('music_assistant')) | list }}
       mass_player_entity_id: |
-        {% if player_entity_id_by_player_name %}
-          {{ player_entity_id_by_player_name }}
-        {% elif player_entity_id_by_area_name %}
-          {{ player_entity_id_by_area_name }}
-        {% elif player_entity_id_by_assist_area  %}
-          {{ player_entity_id_by_assist_area }}
-        {% else %}
-          {{ default_player_entity_id }}
-        {% endif %}
-      mass_player_name: "{{ state_attr(mass_player_entity_id, 'friendly_name') }}"
-  - choose:
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'album' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'track' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              artist: "{{ artist }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'artist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'radio' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
-      - conditions:
-          - condition: template
-            value_template: "{{ media_type == 'playlist' }}"
-        sequence:
-          - action: music_assistant.play_media
-            metadata: {}
-            data:
-              media_id: "{{ media_name }}"
-              media_type: "{{ media_type }}"
-              radio_mode: "{{ radio_mode }}"
-            target:
-              entity_id: "{{ mass_player_entity_id }}"
+        {{ player_entity_id_by_player_name or player_entity_id_by_area_name 
+        or player_entity_id_by_assist_area or [default_player_entity_id] }}
+      mass_player_name: "{{ mass_player_entity_id | map('state_attr', 'friendly_name') | join(', ') }}"
+  - alias: Send media to selected Music Assistant Player
+    action: music_assistant.play_media
+    data: "{{ dict(action_data.items() | selectattr('1')) }}"
+    target:
+      entity_id: "{{ mass_player_entity_id }}"
   - set_conversation_response: "{{ trigger.slots.media_name }} wordt afgespeeld op {{ mass_player_name }}"
 mode: single


### PR DESCRIPTION
Proposal for version management.

Use the current date as version number, we can use a suffix (e.g. 20250128.1) in case there are multiple updates on the same day.

I've added the version as a variable to all the YAML files, this way the version also shows up in the traces, so we can see which version is used.

I updated the NL and DE translations for option 1 to use the same code as the English version.

I created a changelog for each option, in which we can track the changes.

After this is merged, we can create a release (I would suggest to use the same version names) In the release note we can refer to the changelog in case a specific blueprint is changed.

If only small changes to md files are made, I don't think a new release is needed, but when changes to the actual blueprints are done,  we should make a new release.