### PR TITLE
Add Enqueue Mode Configuration

### DIFF
--- a/llm-enhanced-local-assist-blueprint/changelog.md
+++ b/llm-enhanced-local-assist-blueprint/changelog.md
@@ -2,6 +2,10 @@
 
 # Changelog: Option 2 - LLM Enhanced automation
 
+## 20250224
+
+* Feature: Add Enqueue Mode setting
+
 ## 20250129
 
 * fix: correct assistant typo throughout

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -156,6 +156,33 @@ blueprint:
               custom_value: false
               sort: false
           default: Use player settings
+        enqueue_mode:
+          name: Enqueue Mode
+          description:
+            "Determines how media will be enqueued into Music Assistant when requested.
+            \n\n
+            When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
+            \n\n
+            When set to Play now and clear queue, the requested media will play immediately, and all existing media in the queue will be removed.
+            \n\n
+            When set to Play next, the requested media will play after the presently playing media. Once finished, the existing media in the queue will resume.
+            \n\n
+            When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
+            All the prior media in the queue will be removed.
+            \n\n
+            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
+          selector:
+            select:
+              options:
+                - Play
+                - Play now and clear queue
+                - Play next
+                - Play next and clear queue
+                - Add to queue
+              multiple: false
+              custom_value: false
+              sort: false
+          default: Play
     response_settings:
       name: Trigger and response settings for Assist
       icon: mdi:chat
@@ -494,7 +521,7 @@ triggers:
 actions:
   - alias: Store input from blueprint in variables so they can be used in the prompt
     variables:
-      version: 20250210
+      version: 20250224
       expose_areas: !input expose_areas
       expose_players: !input expose_players
       prompt:
@@ -530,6 +557,15 @@ actions:
         radio_mode:
           "{{ false if play_continuously == 'Never' else play_continuously
           == 'Always' and llm_result.action_data.media_type != 'radio' or 'NA' }}"
+        enqueue: >-
+          {%- set enqueue_modes = ({
+          "Play":"play",
+          "Play now and clear queue":"replace",
+          "Play next":"next",
+          "Play next and clear queue":"replace_next",
+          "Add to queue":"add"
+          }) -%}
+          {{enqueue_modes[enqueue_mode]}}
       llm_target_data:
         entity_id:
           "{% set players = llm_result.get('target_data', {}).get('players', []) %}

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -159,7 +159,7 @@ blueprint:
         enqueue_mode:
           name: Enqueue Mode
           description:
-            "Determines how media will be enqueued into Music Assistant when requested.
+            'Determines how media will be enqueued into Music Assistant when requested.
             \n\n
             When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
             \n\n
@@ -170,19 +170,24 @@ blueprint:
             When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
             All the prior media in the queue will be removed.
             \n\n
-            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
+            When set to Add to queue, this song will be added to the existing queue, without interrupting playback.'
           selector:
             select:
               options:
-                - Play
-                - Play now and clear queue
-                - Play next
-                - Play next and clear queue
-                - Add to queue
+                - label: Play
+                  value: play
+                - label: Play now and clear queue
+                  value: replace
+                - label: Play next
+                  value: next
+                - label: Play next and clear queue
+                  value: replace_next
+                - label: Add to queue
+                  value: add
               multiple: false
               custom_value: false
               sort: false
-          default: Play
+          default: play
     response_settings:
       name: Trigger and response settings for Assist
       icon: mdi:chat
@@ -557,15 +562,7 @@ actions:
         radio_mode:
           "{{ false if play_continuously == 'Never' else play_continuously
           == 'Always' and llm_result.action_data.media_type != 'radio' or 'NA' }}"
-        enqueue: >-
-          {%- set enqueue_modes = ({
-          "Play":"play",
-          "Play now and clear queue":"replace",
-          "Play next":"next",
-          "Play next and clear queue":"replace_next",
-          "Add to queue":"add"
-          }) -%}
-          {{enqueue_modes[enqueue_mode]}}
+        enqueue: "{{enqueue_mode}}"
       llm_target_data:
         entity_id:
           "{% set players = llm_result.get('target_data', {}).get('players', []) %}

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -554,6 +554,7 @@ actions:
     variables:
       llm_result: "{{ result.response.speech.plain.speech | from_json }}"
       play_continuously: !input play_continuously
+      enqueue_mode: !input enqueue_mode
       llm_action_data:
         media_id: "{{ llm_result.action_data.media_id }}"
         media_type: "{{ llm_result.action_data.media_type }}"

--- a/llm-script-blueprint/changelog.md
+++ b/llm-script-blueprint/changelog.md
@@ -2,6 +2,10 @@
 
 # Changelog: Option 3 - Full LLM Script
 
+## 20250224
+
+* Feature: Add Enqueue Mode setting
+
 ## 20250129
 
 * fix: correct assistant typo throughout

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -119,7 +119,7 @@ blueprint:
         enqueue_mode:
           name: Enqueue Mode
           description:
-            "Determines how media will be enqueued into Music Assistant when requested.
+            'Determines how media will be enqueued into Music Assistant when requested.
             \n\n
             When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
             \n\n
@@ -130,19 +130,24 @@ blueprint:
             When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
             All the prior media in the queue will be removed.
             \n\n
-            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
+            When set to Add to queue, this song will be added to the existing queue, without interrupting playback.'
           selector:
             select:
               options:
-                - Play
-                - Play now and clear queue
-                - Play next
-                - Play next and clear queue
-                - Add to queue
+                - label: Play
+                  value: play
+                - label: Play now and clear queue
+                  value: replace
+                - label: Play next
+                  value: next
+                - label: Play next and clear queue
+                  value: replace_next
+                - label: Add to queue
+                  value: add
               multiple: false
               custom_value: false
               sort: false
-          default: Play
+          default: play
     prompt_settings:
       name: Prompt settings for the LLM
       icon: mdi:robot
@@ -404,15 +409,7 @@ sequence:
         radio_mode:
           "{{ false if play_continuously == 'Never' else play_continuously
           == 'Always' and media_type != 'radio' or 'NA' }}"
-        enqueue: >-
-          {%- set enqueue_modes = ({
-          "Play":"play",
-          "Play now and clear queue":"replace",
-          "Play next":"next",
-          "Play next and clear queue":"replace_next",
-          "Add to queue":"add"
-          }) -%}
-          {{enqueue_modes[enqueue_mode]}}
+        enqueue: "{{enqueue_mode}}"
   - alias: Play music using Music Assistant
     action: music_assistant.play_media
     data: "{{ dict(action_data.items() | rejectattr('1', 'eq', 'NA')) }}"

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -399,6 +399,7 @@ sequence:
         response_variable: invalid_target
   - variables:
       play_continuously: !input play_continuously
+      enqueue_mode: !input enqueue_mode
       action_data:
         media_id:
           "{{ media_id.split(';') | map('trim') | list if ';' in media_id

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -116,6 +116,33 @@ blueprint:
               custom_value: false
               sort: false
           default: Use player settings
+        enqueue_mode:
+          name: Enqueue Mode
+          description:
+            "Determines how media will be enqueued into Music Assistant when requested.
+            \n\n
+            When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
+            \n\n
+            When set to Play now and clear queue, the requested media will play immediately, and all existing media in the queue will be removed.
+            \n\n
+            When set to Play next, the requested media will play after the presently playing media. Once finished, the existing media in the queue will resume.
+            \n\n
+            When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
+            All the prior media in the queue will be removed.
+            \n\n
+            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
+          selector:
+            select:
+              options:
+                - Play
+                - Play now and clear queue
+                - Play next
+                - Play next and clear queue
+                - Add to queue
+              multiple: false
+              custom_value: false
+              sort: false
+          default: Play
     prompt_settings:
       name: Prompt settings for the LLM
       icon: mdi:robot
@@ -330,7 +357,7 @@ fields:
     description: !input media_player_prompt
 sequence:
   - variables:
-      version: 20250128
+      version: 20250224
       default_player: !input default_player
       player_data: "{% set ma = integration_entities('music_assistant') %}
 
@@ -377,6 +404,15 @@ sequence:
         radio_mode:
           "{{ false if play_continuously == 'Never' else play_continuously
           == 'Always' and media_type != 'radio' or 'NA' }}"
+        enqueue: >-
+          {%- set enqueue_modes = ({
+          "Play":"play",
+          "Play now and clear queue":"replace",
+          "Play next":"next",
+          "Play next and clear queue":"replace_next",
+          "Add to queue":"add"
+          }) -%}
+          {{enqueue_modes[enqueue_mode]}}
   - alias: Play music using Music Assistant
     action: music_assistant.play_media
     data: "{{ dict(action_data.items() | rejectattr('1', 'eq', 'NA')) }}"

--- a/local-assist-blueprint/changelog.md
+++ b/local-assist-blueprint/changelog.md
@@ -2,6 +2,10 @@
 
 # Changelog: Option 1 - Fully local automation
 
+## 20250224
+
+* Feature: Add Enqueue Mode setting
+
 ## 20250128
 
 * Initial version when the changelog was created

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -86,7 +86,7 @@ blueprint:
           filter:
             integration: music_assistant
             domain: media_player
-    enqueue_mode:
+    enqueue_mode_input:
       name: Enqueue Mode
       description:
         'Determines how media will be enqueued into Music Assistant when requested.
@@ -208,6 +208,7 @@ actions:
     variables:
       version: 20250224
       default_player_entity_id: !input default_player_entity_id_input
+      enqueue_mode: !input enqueue_mode_input
       trigger_id: "{{ trigger.id }}"
       area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
       assist_device_id: "{{ trigger.device_id }}"

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -86,6 +86,33 @@ blueprint:
           filter:
             integration: music_assistant
             domain: media_player
+    enqueue_mode:
+          name: Enqueue Mode
+          description:
+            "Determines how media will be enqueued into Music Assistant when requested.
+            \n\n
+            When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
+            \n\n
+            When set to Play now and clear queue, the requested media will play immediately, and all existing media in the queue will be removed.
+            \n\n
+            When set to Play next, the requested media will play after the presently playing media. Once finished, the existing media in the queue will resume.
+            \n\n
+            When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
+            All the prior media in the queue will be removed.
+            \n\n
+            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
+          selector:
+            select:
+              options:
+                - Play
+                - Play now and clear queue
+                - Play next
+                - Play next and clear queue
+                - Add to queue
+              multiple: false
+              custom_value: false
+              sort: false
+          default: Play
     trigger_response_settings:
       name: Trigger and response settings for Assist
       icon: mdi:chat
@@ -174,7 +201,7 @@ triggers:
 actions:
   - alias: Define variables to be used in the automation
     variables:
-      version: 20250128
+      version: 20250224
       default_player_entity_id: !input default_player_entity_id_input
       trigger_id: "{{ trigger.id }}"
       area_or_player_name: "{{ trigger.slots.area_or_player_name | default }}"
@@ -184,6 +211,15 @@ actions:
         media_type: "{{ 'radio' if 'radio' in media_name | lower else trigger_id }}"
         artist: "{{ trigger.slots.artist | default }}"
         radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default | lower }}"
+        enqueue: >-
+          {%- set enqueue_modes = ({
+          "Play":"play",
+          "Play now and clear queue":"replace",
+          "Play next":"next",
+          "Play next and clear queue":"replace_next",
+          "Add to queue":"add"
+          }) -%}
+          {{enqueue_modes[enqueue_mode]}}
       player_entity_id_by_player_name: >
         {{ integration_entities('music_assistant') | expand 
           | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)

--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -87,32 +87,37 @@ blueprint:
             integration: music_assistant
             domain: media_player
     enqueue_mode:
-          name: Enqueue Mode
-          description:
-            "Determines how media will be enqueued into Music Assistant when requested.
-            \n\n
-            When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
-            \n\n
-            When set to Play now and clear queue, the requested media will play immediately, and all existing media in the queue will be removed.
-            \n\n
-            When set to Play next, the requested media will play after the presently playing media. Once finished, the existing media in the queue will resume.
-            \n\n
-            When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
-            All the prior media in the queue will be removed.
-            \n\n
-            When set to Add to queue, this song will be added to the existing queue, without interrupting playback."
-          selector:
-            select:
-              options:
-                - Play
-                - Play now and clear queue
-                - Play next
-                - Play next and clear queue
-                - Add to queue
-              multiple: false
-              custom_value: false
-              sort: false
-          default: Play
+      name: Enqueue Mode
+      description:
+        'Determines how media will be enqueued into Music Assistant when requested.
+        \n\n
+        When set to Play, the request media will be played immediately, then the prior media in the queue will resume.
+        \n\n
+        When set to Play now and clear queue, the requested media will play immediately, and all existing media in the queue will be removed.
+        \n\n
+        When set to Play next, the requested media will play after the presently playing media. Once finished, the existing media in the queue will resume.
+        \n\n
+        When set to Play next and clear queue, the currently playing media will finish and then the requested media will be queued and start playing.
+        All the prior media in the queue will be removed.
+        \n\n
+        When set to Add to queue, this song will be added to the existing queue, without interrupting playback.'
+      selector:
+        select:
+          options:
+            - label: Play
+              value: play
+            - label: Play now and clear queue
+              value: replace
+            - label: Play next
+              value: next
+            - label: Play next and clear queue
+              value: replace_next
+            - label: Add to queue
+              value: add
+          multiple: false
+          custom_value: false
+          sort: false
+      default: play
     trigger_response_settings:
       name: Trigger and response settings for Assist
       icon: mdi:chat
@@ -211,15 +216,7 @@ actions:
         media_type: "{{ 'radio' if 'radio' in media_name | lower else trigger_id }}"
         artist: "{{ trigger.slots.artist | default }}"
         radio_mode: "{{ 'radio' in trigger.slots.radio_mode | default | lower }}"
-        enqueue: >-
-          {%- set enqueue_modes = ({
-          "Play":"play",
-          "Play now and clear queue":"replace",
-          "Play next":"next",
-          "Play next and clear queue":"replace_next",
-          "Add to queue":"add"
-          }) -%}
-          {{enqueue_modes[enqueue_mode]}}
+        enqueue: "{{enqueue_mode}}"
       player_entity_id_by_player_name: >
         {{ integration_entities('music_assistant') | expand 
           | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)


### PR DESCRIPTION
Adding an Enqueue Mode configuration option to all three voice blueprints, that allows the user to determine how new requests should be enqueued to Music Assistant.

Resolves #59 