### PR TITLE
Provide a default for shuffle in case not set properly by the LLM

### DIFF
--- a/llm-script-blueprint/changelog.md
+++ b/llm-script-blueprint/changelog.md
@@ -17,3 +17,6 @@
 ## 20250416
 
 * Adding additional prompt details for shuffle on the main tool prompt
+
+## 20250526
+* Add default for `shuffle`  setting in case not set properly by LLM

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -354,9 +354,9 @@ fields:
     description: !input shuffle_prompt
 sequence:
 - variables:
-    version: 20250404
+    version: 20250526
     default_player: !input default_player
-    shuffle: '{{ shuffle }}'
+    shuffle: '{{ shuffle | default(false, true) }}'
     player_data: '{% set ma = integration_entities(''music_assistant'') %}
 
       {% set ma_names = ma | map(''state_attr'', ''friendly_name'') | list %}

--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -356,7 +356,7 @@ sequence:
 - variables:
     version: 20250526
     default_player: !input default_player
-    shuffle: '{{ shuffle | default(false, true) }}'
+    shuffle: '{{ shuffle | default(false, true) | bool(false) }}'
     player_data: '{% set ma = integration_entities(''music_assistant'') %}
 
       {% set ma_names = ma | map(''state_attr'', ''friendly_name'') | list %}


### PR DESCRIPTION
Based on this comment on the HA forums, I expect there will be an error in case the LLM doesn't properly set the `shuffle`  field.
https://community.home-assistant.io/t/blueprints-for-voice-commands-weather-calendar-music-assistant/838071/57?u=thefes

So I now added the default value `false`  in case it is not set by the LLM