### PR TITLE
Fix music script to match Music Assistant service schema.

### DIFF
--- a/llm-script-blueprint/llm_voice_script.yaml
+++ b/llm-script-blueprint/llm_voice_script.yaml
@@ -304,19 +304,16 @@ fields:
         - radio
     name: Media Type
     description: !input media_type_prompt
-    required: true
   artist:
     selector:
       text:
     name: Artist
     description: !input artist_prompt
-    required: true
   album:
     selector:
       text:
     name: Album
     description: !input album_prompt
-    required: true
   media_id:
     selector:
       text:
@@ -328,7 +325,6 @@ fields:
       text:
     name: Media Description
     description: !input media_description_prompt
-    required: true
   area:
     selector:
       area:


### PR DESCRIPTION
This PR udates the **music script** to correctly match the required fields specified in the Music Assistant service schema:
https://github.com/home-assistant/core/blob/dev/homeassistant/components/music_assistant/services.yaml

This avoids confusion when calling the script manually, where validation previously failed, while working fine via the assist pipeline.