### PR TITLE
Update mass_assist_blueprint_en.yaml

### DIFF
--- a/local-assist-blueprint/mass_assist_blueprint_en.yaml
+++ b/local-assist-blueprint/mass_assist_blueprint_en.yaml
@@ -201,16 +201,17 @@ actions:
         }}'
       artist: '{{ trigger.slots.artist | default }}'
       radio_mode: '{{ ''radio'' in trigger.slots.radio_mode | default | lower }}'
-    player_entity_id_by_player_name: "{{ integration_entities('music_assistant') |
+    ma_players: '{{  integration_entities(''music_assistant'') | select(''match'', 'media_player'') | list }}'
+    player_entity_id_by_player_name: "{{ ma_players |
       expand \n  | selectattr('name', 'match', area_or_player_name ~ '$', ignorecase=true)\n
       \ | map(attribute='entity_id') | list }}\n"
     player_entity_id_by_area_name: '{{ areas() | map(''area_name'') | select(''match'',
       area_or_player_name ~ ''$'',  ignorecase=true) | map(''area_entities'') | sum(start=[])
-      | select(''in'',  integration_entities(''music_assistant'')) | list }}
+      | select(''in'',  ma_players) | list }}
 
       '
     player_entity_id_by_assist_area: '{{ area_entities(area_id(trigger.device_id))
-      | select(''in'', integration_entities(''music_assistant'')) | list }}
+      | select(''in'', ma_players) | list }}
 
       '
     mass_player_entity_id: "{{ player_entity_id_by_player_name or player_entity_id_by_area_name


### PR DESCRIPTION
Filtered player-related variables to include only `media_player` entities so that `button` entities aren't used in the actions and do not have their names spoken after every action occurs.