### PR TITLE
Ensure LLM assisted automation only returns media players

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -513,7 +513,8 @@ actions:
         []) %} {% set players = players | join(''|'') if players is list else players
         %} {{ integration_entities(''music_assistant'') | expand | selectattr(''name'',
         ''in'', player_names.split('', '') | select(''search'', players, ignorecase=true)
-        | list) | map(attribute=''entity_id'') | list if players else [] }}'
+        | list) | map(attribute=''entity_id'') | select('search', '^media_player.') | 
+        list if players else [] }}'
       area_id: '{% set areas = llm_result.get(''target_data'', {}).get(''areas'',
         []) %} {% set areas = areas | join(''|'') if areas is list else areas %} {{
         area_names.split('', '') | select(''search'', areas, ignorecase=true) | map(''area_id'')


### PR DESCRIPTION
Apparantly button entities are added to play a favorite song, which were now returned by the automation to play media on. An extra filter is added to ensure only media_player entities are returned.