### PR TITLE
Only include defined areas in area_names variable

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -484,7 +484,7 @@ actions:
       target: !input llm_prompt_target
       outro: !input llm_prompt_outro
     area_names: '{{ integration_entities(''music_assistant'')  | map(''area_name'')
-      | join('', '') }}'
+      | reject(''none'') | join('', '') }}'
     player_names: '{{ integration_entities(''music_assistant'') | map(''state_attr'',
       ''friendly_name'') | join('', '') }}'
 - alias: Send the request to the LLM


### PR DESCRIPTION
Omit `None` values from list of areas. This prevents #103 in cases where no valid area values are defined.