### PR TITLE
Fixing English LLM blueprint issue

### DIFF
--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -513,7 +513,7 @@ actions:
         []) %} {% set players = players | join(''|'') if players is list else players
         %} {{ integration_entities(''music_assistant'') | expand | selectattr(''name'',
         ''in'', player_names.split('', '') | select(''search'', players, ignorecase=true)
-        | list) | map(attribute=''entity_id'') | select('search', '^media_player.') | 
+        | list) | map(attribute=''entity_id'') | 
         list if players else [] }}'
       area_id: '{% set areas = llm_result.get(''target_data'', {}).get(''areas'',
         []) %} {% set areas = areas | join(''|'') if areas is list else areas %} {{

--- a/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
+++ b/llm-enhanced-local-assist-blueprint/mass_llm_enhanced_assist_blueprint_en.yaml
@@ -513,7 +513,7 @@ actions:
         []) %} {% set players = players | join(''|'') if players is list else players
         %} {{ integration_entities(''music_assistant'') | expand | selectattr(''name'',
         ''in'', player_names.split('', '') | select(''search'', players, ignorecase=true)
-        | list) | map(attribute=''entity_id'') | 
+        | list) | map(attribute=''entity_id'') | select(''search'', ''^media_player.'') | 
         list if players else [] }}'
       area_id: '{% set areas = llm_result.get(''target_data'', {}).get(''areas'',
         []) %} {% set areas = areas | join(''|'') if areas is list else areas %} {{


### PR DESCRIPTION
When attempting to import the blueprint, I kept recieving the following error

```
while parsing a block mapping in "<unicode string>", line 512, column 7: entity_id: '{% set players = llm ... ^ expected <block end>, but found '<scalar>' in "<unicode string>", line 516, column 58: ... ribute=''entity_id'') | select('search', '^media_player.') | ^
```
Seemingly due to single, rather than double, quote marks. Added these in and it seems to import and work.